### PR TITLE
Eliminate unexpected type coercion warnings.

### DIFF
--- a/dialogs/token.js
+++ b/dialogs/token.js
@@ -9,7 +9,7 @@ CKEDITOR.dialog.add( 'token', function( editor ) {
 	var lang = editor.lang.token;
 	var	generalLabel = editor.lang.common.generalTab;
 	var tokens = [["",""]];
-	if (typeof editor.config.availableTokens != "undefined") {
+	if (typeof editor.config.availableTokens !== "undefined") {
 		tokens = editor.config.availableTokens;
 	}
 

--- a/plugin.js
+++ b/plugin.js
@@ -26,10 +26,10 @@ function escapeRegExp(string){
 			var lang = editor.lang.token;
 			var tokenStart = '${';
             var tokenEnd = '}';
-            if (typeof editor.config.tokenStart != 'undefined') {
+            if (typeof editor.config.tokenStart !== 'undefined') {
                 tokenStart = editor.config.tokenStart;
             }
-            if (typeof editor.config.tokenEnd != 'undefined') {
+            if (typeof editor.config.tokenEnd !== 'undefined') {
                 tokenEnd = editor.config.tokenEnd;
             }
             var tokenStartNum = tokenStart.length;
@@ -73,10 +73,10 @@ function escapeRegExp(string){
 
             var tokenStart = '${';
             var tokenEnd = '}';
-            if (typeof editor.config.tokenStart != 'undefined') {
+            if (typeof editor.config.tokenStart !== 'undefined') {
                 tokenStart = editor.config.tokenStart;
             }
-            if (typeof editor.config.tokenEnd != 'undefined') {
+            if (typeof editor.config.tokenEnd !== 'undefined') {
                 tokenEnd = editor.config.tokenEnd;
             }
             var tokenStartRegex = escapeRegExp(tokenStart);


### PR DESCRIPTION
This removes unexpected type coercion warnings you might encounter in IDEs. This uses non-converting comparison operators.